### PR TITLE
Fix error on installation with enable-zookeeper.

### DIFF
--- a/jubatus.rb
+++ b/jubatus.rb
@@ -1,7 +1,8 @@
 require 'formula'
 
-class ZooKeeperLib < Requirement
+class ZooKeeperRequirement < Requirement
   def initialize
+    super
     @zk = Formula.factory('zookeeper')
   end
 
@@ -45,7 +46,7 @@ class Jubatus < Formula
   depends_on 'pficommon'
   depends_on 'jubatus-msgpack-rpc'
 
-  depends_on ZooKeeperLib.new if build.include? 'enable-zookeeper'
+  depends_on ZooKeeperRequirement.new if build.include? 'enable-zookeeper'
   depends_on 'mecab' if build.include? 'enable-mecab'
   depends_on 're2' if build.include? 'enable-re2'
   # snow leopard default gcc version is 4.2


### PR DESCRIPTION
This change fixes error on installing jubatus with enable-zookeeper.

Requirement class automatically generates in its constructor the formula name using the name of deriving class.
In the case of jubatus, if the requirement name is ZooKeeperRequirement, then it sets @name = 'zookeeper'.
We can also set it manually in constructor, but naming with prefix 'Requirement' or 'Dependency' is maybe the homebrew way (I think so because such automatic behavior exists), so I obeyed it.
