### PR TITLE
Fix README for jubatus-core.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ The following options are available:
 
 Example:
 
-    $ brew install jubatus --use-clang --disable-onig --enable-zookeeper
+    $ brew install jubatus-core --use-clang --regexp-library=re2
+    $ brew install jubatus --use-clang --enable-zookeeper
 
 ## Requirement
 


### PR DESCRIPTION
Dependency to regex libraries is moved to jubatus-core, so fixed README.
