### PR TITLE
missing dependency for msgpack in jubatus-core

### DIFF
--- a/jubatus-core.rb
+++ b/jubatus-core.rb
@@ -14,6 +14,7 @@ class JubatusCore < Formula
   end
 
   depends_on 'pkg-config'
+  depends_on 'msgpack'
 
   depends_on 'oniguruma' if @@regexp_library == 'oniguruma'
   depends_on 're2' if @@regexp_library == 're2'


### PR DESCRIPTION
`jubatus-core` depends on `msgpack` but dependency in formula is missing.

BTW, it worked fine on Yosemite Beta :tada:
