### PR TITLE
Fix SHA1 value of release 0.2.8

### DIFF
--- a/jubatus-core.rb
+++ b/jubatus-core.rb
@@ -2,7 +2,7 @@ class JubatusCore < Formula
   url 'https://github.com/jubatus/jubatus_core/tarball/0.2.8'
   head 'https://github.com/jubatus/jubatus_core.git'
   homepage 'http://jubat.us/'
-  sha1 '031af0cdff9348d3aa46321a21e02121f7f2f3e0'
+  sha1 '6558173e289d514f47bc5dfb29b2e20b04a7f546'
   version '0.2.8'
 
   option 'regexp-library=', 'oniguruma (default), re2, or none'

--- a/jubatus.rb
+++ b/jubatus.rb
@@ -32,7 +32,7 @@ class Jubatus < Formula
   url 'https://github.com/jubatus/jubatus/tarball/0.8.8'
   head 'https://github.com/jubatus/jubatus.git'
   homepage 'http://jubat.us/'
-  sha1 '088c45e221aed19c87496cb2a0bc6da313d1100e'
+  sha1 '03234a365ff716b4285085f6c59822e145c9e2b6'
   version '0.8.8'
 
   option 'enable-mecab', 'Enable mecab for Japanese NLP'


### PR DESCRIPTION
I got the below message when `brew install`-ed:

```
$ brew install jubatus --use-clang
==> Installing jubatus from jubatus/jubatus
==> Installing dependencies for jubatus/jubatus/jubatus: jubatus-core, jubatus-mpio, jubatus-msgpack-rp
==> Installing jubatus/jubatus/jubatus dependency: jubatus-core
==> Downloading https://github.com/jubatus/jubatus_core/tarball/0.2.8
==> Downloading from https://codeload.github.com/jubatus/jubatus_core/legacy.tar.gz/0.2.8
Error: SHA1 mismatch
Expected: 031af0cdff9348d3aa46321a21e02121f7f2f3e0
Actual: 6558173e289d514f47bc5dfb29b2e20b04a7f546
Archive: /Library/Caches/Homebrew/jubatus-core-0.2.8.8
To retry an incomplete download, remove the file above.
```

It seems because the SHA1 value is mistakenly set from some other thing not the correct one.

```
$ wget https://github.com/jubatus/jubatus_core/tarball/0.2.8
--2016-03-17 16:01:20--  https://github.com/jubatus/jubatus_core/tarball/0.2.8
Resolving github.com... 192.30.252.131
Connecting to github.com|192.30.252.131|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://codeload.github.com/jubatus/jubatus_core/legacy.tar.gz/0.2.8 [following]
--2016-03-17 16:01:22--  https://codeload.github.com/jubatus/jubatus_core/legacy.tar.gz/0.2.8
Resolving codeload.github.com... 192.30.252.160
Connecting to codeload.github.com|192.30.252.160|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 1229074 (1.2M) [application/x-gzip]
Saving to: '0.2.8'

0.2.8                       100%[=========================================>]   1.17M   342KB/s    in 3.5s

2016-03-17 16:01:27 (342 KB/s) - '0.2.8' saved [1229074/1229074]

$ openssl sha1 0.2.8
SHA1(0.2.8)= 6558173e289d514f47bc5dfb29b2e20b04a7f546
```

Or something wrong happened in the tarball?