### PR TITLE
Add --without-fmv option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,15 @@ We will modify jubatus to use latest msgack-c, but use old msgpack-c for now.
 	$ brew tap jubatus/jubatus
 	$ brew install jubatus --use-clang
 
+On Catalina, Please specify option `--without-fmv`.
+
 ## Configure Options
 
 The following options are available:
 
 * --enable-mecab: Enable mecab
 * --enable-zookeeper: Enable ZooKeeper (distributed mode)
+* --without-fmv: Disable optimization using function multiversioning
 
 Example:
 

--- a/jubatus-core.rb
+++ b/jubatus-core.rb
@@ -10,6 +10,7 @@ class JubatusCore < Formula
   if @@regexp_library.nil?
     @@regexp_library = 'oniguruma'
   end
+  option 'without-fmv', 'Disable optimization using function multiversioning'
 
   depends_on 'pkg-config' => :build
   depends_on 'msgpack059'
@@ -23,7 +24,9 @@ class JubatusCore < Formula
     if MacOS.version >= :mavericks
       ENV['CXXFLAGS'] = '-std=c++11'
     end
-    system './waf', 'configure', "--prefix=#{prefix}", "--regexp-library=#{@@regexp_library}"
+    args = []
+    args << '--disable-fmv' if build.without? "fmv"
+    system './waf', 'configure', "--prefix=#{prefix}", "--regexp-library=#{@@regexp_library}", *args
     system './waf'
     system './waf', 'install'
   end


### PR DESCRIPTION
On Catalina, installation is failed.

```
==> Downloading https://github.com/jubatus/jubatus_core/archive/1.1.1.tar.gz
==> Downloading from https://codeload.github.com/jubatus/jubatus_core/tar.gz/1.1.1
##=O#- #
==> ./waf configure --prefix=/usr/local/Cellar/jubatus-core/1.1.1 --regexp-library=oniguruma
==> ./waf
Last 15 lines from /Users/imama-r/Library/Logs/Homebrew/jubatus-core/02.waf:
  "jubatus::util::math::random::random<jubatus::util::math::random::sfmt<607u, 2, 15, 3, 13, 3, 4261361663u, 4018093949u, 4286020477u, 2146958127u, 1u, 0u, 0u, 1502015572u> >::~random()", referenced from:
      jubatus::core::nearest_neighbor::(anonymous namespace)::random_projection_internal(std::__1::vector<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double> > > const&, unsigned int, unsigned long, unsigned long, jubatus::util::lang::scoped_ptr<jubatus::core::nearest_neighbor::random_projection_cache>&) (.resolver) in lsh_function.cpp.2.o
      jubatus::core::nearest_neighbor::(anonymous namespace)::random_projection_internal(std::__1::vector<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double> > > const&, unsigned int, unsigned long, unsigned long, jubatus::util::lang::scoped_ptr<jubatus::core::nearest_neighbor::random_projection_cache>&) (.avx2) in lsh_function.cpp.2.o
  "std::__1::vector<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double> > >::operator[](unsigned long) const", referenced from:
      jubatus::core::nearest_neighbor::(anonymous namespace)::random_projection_internal(std::__1::vector<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double> > > const&, unsigned int, unsigned long, unsigned long, jubatus::util::lang::scoped_ptr<jubatus::core::nearest_neighbor::random_projection_cache>&) (.resolver) in lsh_function.cpp.2.o
      jubatus::core::nearest_neighbor::(anonymous namespace)::random_projection_internal(std::__1::vector<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double> > > const&, unsigned int, unsigned long, unsigned long, jubatus::util::lang::scoped_ptr<jubatus::core::nearest_neighbor::random_projection_cache>&) (.avx2) in lsh_function.cpp.2.o
  "std::__1::vector<float, std::__1::allocator<float> >::data()", referenced from:
      jubatus::core::nearest_neighbor::(anonymous namespace)::random_projection_internal(std::__1::vector<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double> > > const&, unsigned int, unsigned long, unsigned long, jubatus::util::lang::scoped_ptr<jubatus::core::nearest_neighbor::random_projection_cache>&) (.resolver) in lsh_function.cpp.2.o
      jubatus::core::nearest_neighbor::(anonymous namespace)::random_projection_internal(std::__1::vector<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, double> > > const&, unsigned int, unsigned long, unsigned long, jubatus::util::lang::scoped_ptr<jubatus::core::nearest_neighbor::random_projection_cache>&) (.avx2) in lsh_function.cpp.2.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)

Waf: Leaving directory `/private/tmp/jubatus-core-20200128-50648-1o32y0j/jubatus_core-1.1.1/build'
Build failed
 -> task in 'jubatus_core' failed with exit status 1 (run with -v to display more information)
```

This patch add ``--without-fmv`` option to building jubatus-core.
To build on Catalina, we should specify this option. 